### PR TITLE
Adjust booking advance time and fix calendar label

### DIFF
--- a/src/components/BookingFlow.js
+++ b/src/components/BookingFlow.js
@@ -63,8 +63,8 @@ export default function BookingFlow() {
     const diffMs = selectedDate.getTime() - nowColombo.getTime();
     const diffHours = diffMs / (1000 * 60 * 60);
     
-    if (diffHours < 24) {
-      alert('Bookings must be made at least 24 hours in advance. Please select a later date.');
+    if (diffHours < 22.5) {
+      alert('Bookings must be made at least 1 day in advance. Please select a later date.');
       return;
     }
     

--- a/src/components/StepCalendar.js
+++ b/src/components/StepCalendar.js
@@ -164,7 +164,7 @@ export default function StepCalendar({
               title={"Select 09:00 AM"}
               disabled={isFull}
             >
-              10:30 AM
+              9:00 AM
             </button>
 
             {isLoadingCount ? (


### PR DESCRIPTION
Changed the minimum advance booking time from 24 to 22.5 hours and updated the calendar button label from '10:30 AM' to '9:00 AM' to match the button's title.